### PR TITLE
Python 3 compatibility, handling of additional message types, other minor adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 aislib
 ======
 
-A Python library for decoding and encoding: 
+A Python library for decoding and encoding:
  * AIS type 1 messages
  * AIS type 5 messages
+ * AIS type 21 messages
  * AIS type 24 part A and Part B messages (main craft case )
- 
+
 As there exist reliable and comprehensive python decoders, the emphasis is on encoding.
 
 It is easy but boring to add further messages types, I will do it only if the need arises.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ aislib
 ======
 
 A Python library for decoding and encoding:
- * AIS type 1 messages
+ * AIS type 1/2/3 messages
  * AIS type 5 messages
  * AIS type 21 messages
  * AIS type 24 part A and Part B messages (main craft case )

--- a/README.md
+++ b/README.md
@@ -9,9 +9,6 @@ A Python library for decoding and encoding:
 
 As there exist reliable and comprehensive python decoders, the emphasis is on encoding.
 
-It is easy but boring to add further messages types, I will do it only if the need arises.
-To do it you need to read carefully the documentation, the best source I have found is http://catb.org/gpsd/AIVDM.html
-
 The bitstring Python library is a required dependency. You can get it here: https://pypi.python.org/pypi/bitstring
 
 TODO

--- a/aislib.py
+++ b/aislib.py
@@ -158,8 +158,8 @@ class AISMessage(object):
         pass
         
 class AISPositionReportMessage(AISMessage):
-    def __init__(self, id=1, repeat=0, mmsi=0, status=15, rot=-128, sog=0, pa=0,
-                       lon=0, lat=0, cog=3600, heading=511, ts=60, smi=0, spare=0, 
+    def __init__(self, id=1, repeat=0, mmsi=0, status=15, rot=0, sog=1023, pa=0,
+                       lon=181, lat=91, cog=3600, heading=511, ts=60, smi=0, spare=0, 
                        raim=0, comm_state=0):
         """
         Returns an instance of an AIS Position Report Message class

--- a/aislib.py
+++ b/aislib.py
@@ -84,7 +84,6 @@ class AISMessage(object):
             # arr[1] == number of bits for given element
             # arr[2] == the default value for the element
             self._bitmap[key] = [ arr[0], arr[1] ]
-            
             # Set default value
             self.__setattr__(key, arr[2])
 
@@ -270,8 +269,8 @@ class AISStaticAndVoyageReportMessage(AISMessage):
                     'mmsi'         : ["uint", 30, mmsi], 
                     'ais_version'  : ["uint", 2, ais_version], 
                     'imo'          : ["uint", 30, imo], 
-                    'callsign'     : ["uint", 42, AISString2Bits(callsign,length=old_div(42,6)).int if type(callsign) == str else callsign], 
-                    'shipname'     : ["uint", 120, AISString2Bits(shipname,length=old_div(120,6)).int if type(shipname) == str else shipname], 
+                    'callsign'     : ["int", 42, AISString2Bits(callsign,length=old_div(42,6)).int if type(callsign) == str else callsign], 
+                    'shipname'     : ["int", 120, AISString2Bits(shipname,length=old_div(120,6)).int if type(shipname) == str else shipname], 
                     'shiptype'     : ["uint", 8, shiptype], 
                     'to_bow'       : ["uint", 9, to_bow], 
                     'to_stern'     : ["uint", 9, to_stern], 
@@ -283,7 +282,7 @@ class AISStaticAndVoyageReportMessage(AISMessage):
                     'hour'         : ["uint", 5, hour], 
                     'minute'       : ["uint", 6, minute], 
                     'draught'      : ["uint", 8, draught], 
-                    'destination'  : ["uint", 120, AISString2Bits(destination,length=old_div(120,6)).int if type(destination) == str else destination], 
+                    'destination'  : ["int", 120, AISString2Bits(destination,length=old_div(120,6)).int if type(destination) == str else destination], 
                     'dte'          : ["uint", 1, dte], 
                     'spare'        : ["uint", 1, spare]
                 })
@@ -358,7 +357,7 @@ class AISStaticDataReportAMessage(AISMessage):
                     'repeat'          : ["uint", 2, repeat], 
                     'mmsi'            : ["uint", 30, mmsi], 
                     'partno'          : ["uint", 2, partno], 
-                    'shipname'        : ["uint", 120, AISString2Bits(shipname,length=old_div(120,6)).int if type(shipname) == str else shipname], 
+                    'shipname'        : ["int", 120, AISString2Bits(shipname,length=old_div(120,6)).int if type(shipname) == str else shipname], 
                     'spare'           : ["uint", 8, spare]
                 })
 
@@ -406,10 +405,10 @@ class AISStaticDataReportBMessage(AISMessage):
                     'mmsi'            : ["uint", 30, mmsi], 
                     'partno'          : ["uint", 2, partno], 
                     'shiptype'        : ["uint", 8, shiptype], 
-                    'vendorid'        : ["uint", 18, AISString2Bits(vendorid,length=old_div(18,6)).int if type(vendorid) == str else vendorid], 
+                    'vendorid'        : ["int", 18, AISString2Bits(vendorid,length=old_div(18,6)).int if type(vendorid) == str else vendorid], 
                     'model'           : ["uint", 4, model], 
                     'serial'          : ["uint", 20, serial], 
-                    'callsign'        : ["uint", 42, AISString2Bits(callsign,length=old_div(42,6)).int if type(callsign) == str else callsign], 
+                    'callsign'        : ["int", 42, AISString2Bits(callsign,length=old_div(42,6)).int if type(callsign) == str else callsign], 
                     'to_bow'          : ["uint", 9, to_bow], 
                     'to_stern'        : ["uint", 9, to_stern], 
                     'to_port'         : ["uint", 6, to_port], 
@@ -539,7 +538,7 @@ class AISBinaryBroadcastMessageAreaNoticeCircle(AISMessage):
 class AISAtonReport(AISMessage):
 
 
-    def __init__(self, repeat = 0, mmsi = 0, aid_type = 0, name = 0, accuracy = 0, lon = 181000, lat = 91000, to_bow = 0, to_stern = 0, to_port = 0, to_starboard = 0, epfd = 0, ts = 60, off_position = 0, raim = 0, virtual_aid = 0, assigned = 0):
+    def __init__(self, repeat = 0, mmsi = 0, aid_type = 0, name = 0, accuracy = 0, lon = 181000, lat = 91000, to_bow = 0, to_stern = 0, to_port = 0, to_starboard = 0, epfd = 0, ts = 60, off_position = 0, raim = 0, virtual_aid = 0, assigned = 0, name_ext = 0):
 
         super(AISAtonReport, self).__init__({
                     # message_element : ["data_type", num_bits, initial_value]
@@ -547,7 +546,7 @@ class AISAtonReport(AISMessage):
                     'repeat'          : ["uint", 2, repeat], 
                     'mmsi'            : ["uint", 30, mmsi], 
                     'aid_type'        : ["uint", 5, aid_type], 
-                    'name'            : ["uint", 120, AISString2Bits(name,length=old_div(120,6)).int if type(name) == str else name], 
+                    'name'            : ["int", 120, AISString2Bits(name,length=old_div(120,6)).int if type(name) == str else name], 
                     'accuracy'        : ["uint", 1, accuracy],
                     'lon'             : ["int", 28, lon], 
                     'lat'             : ["int", 27, lat], 
@@ -563,6 +562,7 @@ class AISAtonReport(AISMessage):
                     'virtual_aid'     : ["uint", 1, virtual_aid], 
                     'assigned'        : ["uint", 1, assigned], 
                     'spare'           : ["uint", 1, 0],
+                    'name_ext'        : ["int", 84, AISString2Bits(name_ext,length=old_div(84,6)).int if type(name_ext) == str else name_ext], 
                     'pad'             : ["uint", 4, 0]
                 })
 
@@ -589,6 +589,7 @@ class AISAtonReport(AISMessage):
             self.virtual_aid,
             self.assigned,
             self.spare,
+            self.name_ext,
             self.pad
         ])
 
@@ -615,7 +616,8 @@ class AISAtonReport(AISMessage):
         self._attrs["virtual_aid"]  = bitstring.Bits(bin=bitstream[269:270])
         self._attrs["assigned"]     = bitstring.Bits(bin=bitstream[270:271])
         self._attrs["spare"]        = bitstring.Bits(bin=bitstream[271:272])
-        self._attrs["pad"]          = bitstring.Bits(bin=bitstream[272:276])
+        self._attrs["name_ext"]     = bitstring.Bits(bin=bitstream[272:356])
+        self._attrs["pad"]          = bitstring.Bits(bin=bitstream[356:360])
 
 
 

--- a/aislib.py
+++ b/aislib.py
@@ -703,7 +703,7 @@ class AIS(object):
         return ("".join(encoded_str))+','+chr(ord('0')+fillbits)
 
 
-    def decode(self, msg):
+    def decode(self, msg, ignore_crc = False):
 
         """
         Decodes an AIS NMEA formatted message. Currently supports message 
@@ -719,7 +719,7 @@ class AIS(object):
         given_crc = int(msg[-2:], 16)
 
         # If CRC did not match, throw exception!
-        if given_crc != computed_crc:
+        if given_crc != computed_crc and not ignore_crc : 
             raise CRCInvalidError("The given CRC did not match the computed CRC.")
             
         # Otherwise we can continue with decoding the message
@@ -745,7 +745,12 @@ class AIS(object):
             bitstream = bitstream[:-int(fillbits[0])]
 
         msgId = bitstream[0:6]  #;print msgId
+
         if   msgId == '000001':
+             aismsg = AISPositionReportMessage()
+        elif  msgId == '000010':
+             aismsg = AISPositionReportMessage()
+        elif  msgId == '000011':
              aismsg = AISPositionReportMessage()
         elif msgId == '011000' and bitstream[38] == '0':
              aismsg = AISStaticDataReportAMessage()

--- a/aislib.py
+++ b/aislib.py
@@ -10,7 +10,12 @@ This program is licensed under the GNU GENERAL PUBLIC LICENSE Version 2.
 A LICENSE file should have accompanied this program.
  
 """
+from __future__ import division
 
+from builtins import chr
+from builtins import range
+from past.utils import old_div
+from builtins import object
 import bitstring
 import binascii
     
@@ -62,7 +67,7 @@ class AISMessage(object):
     
     def __init__(self, elements):
         # Init our bit mapping and load up default message values
-        for key, arr in elements.iteritems():
+        for key, arr in elements.items():
             # arr[0] == data type of the element
             # arr[1] == number of bits for given element
             # arr[2] == the default value for the element
@@ -92,7 +97,7 @@ class AISMessage(object):
         We are overriding the __setattr__ to implement dynamic property "setters".
         """
         
-        if type(value) not in [ int,long]:
+        if type(value) not in [ int,int]:
             raise TypeError("Value must be an integer.")
             
         if name == "_bitmap":
@@ -244,8 +249,8 @@ class AISStaticAndVoyageReportMessage(AISMessage):
                     'mmsi'         : ["uint", 30, mmsi], 
                     'ais_version'  : ["uint", 2, ais_version], 
                     'imo'          : ["uint", 30, imo], 
-                    'callsign'     : ["uint", 42, AISString2Bits(callsign,length=42/6).int if type(callsign) == str else callsign], 
-                    'shipname'     : ["uint", 120, AISString2Bits(shipname,length=120/6).int if type(shipname) == str else shipname], 
+                    'callsign'     : ["uint", 42, AISString2Bits(callsign,length=old_div(42,6)).int if type(callsign) == str else callsign], 
+                    'shipname'     : ["uint", 120, AISString2Bits(shipname,length=old_div(120,6)).int if type(shipname) == str else shipname], 
                     'shiptype'     : ["uint", 8, shiptype], 
                     'to_bow'       : ["uint", 9, to_bow], 
                     'to_stern'     : ["uint", 9, to_stern], 
@@ -257,7 +262,7 @@ class AISStaticAndVoyageReportMessage(AISMessage):
                     'hour'         : ["uint", 5, hour], 
                     'minute'       : ["uint", 6, minute], 
                     'draught'      : ["uint", 8, draught], 
-                    'destination'  : ["uint", 120, AISString2Bits(destination,length=120/6).int if type(destination) == str else destination], 
+                    'destination'  : ["uint", 120, AISString2Bits(destination,length=old_div(120,6)).int if type(destination) == str else destination], 
                     'dte'          : ["uint", 1, dte], 
                     'spare'        : ["uint", 1, spare]
                 })
@@ -327,7 +332,7 @@ class AISStaticDataReportAMessage(AISMessage):
                     'repeat'          : ["uint", 2, repeat], 
                     'mmsi'            : ["uint", 30, mmsi], 
                     'partno'          : ["uint", 2, partno], 
-                    'shipname'        : ["uint", 120, AISString2Bits(shipname,length=120/6).int if type(shipname) == str else shipname], 
+                    'shipname'        : ["uint", 120, AISString2Bits(shipname,length=old_div(120,6)).int if type(shipname) == str else shipname], 
                     'spare'           : ["uint", 8, spare]
                 })
     
@@ -371,10 +376,10 @@ class AISStaticDataReportBMessage(AISMessage):
                     'mmsi'            : ["uint", 30, mmsi], 
                     'partno'          : ["uint", 2, partno], 
                     'shiptype'        : ["uint", 8, shiptype], 
-                    'vendorid'        : ["uint", 18, AISString2Bits(vendorid,length=18/6).int if type(vendorid) == str else vendorid], 
+                    'vendorid'        : ["uint", 18, AISString2Bits(vendorid,length=old_div(18,6)).int if type(vendorid) == str else vendorid], 
                     'model'           : ["uint", 4, model], 
                     'serial'          : ["uint", 20, serial], 
-                    'callsign'        : ["uint", 42, AISString2Bits(callsign,length=42/6).int if type(callsign) == str else callsign], 
+                    'callsign'        : ["uint", 42, AISString2Bits(callsign,length=old_div(42,6)).int if type(callsign) == str else callsign], 
                     'to_bow'          : ["uint", 9, to_bow], 
                     'to_stern'        : ["uint", 9, to_stern], 
                     'to_port'         : ["uint", 6, to_port], 
@@ -571,4 +576,3 @@ class AIS(object):
             chksum = chksum ^ ord(c)
             
         return chksum
-

--- a/aistest.py
+++ b/aistest.py
@@ -1,9 +1,13 @@
 from __future__ import print_function
 
 import aislib
+
 #
 # Tests for Message Type 1
 #
+
+print('Tests for Message Type 1')
+
 aismsg = aislib.AISPositionReportMessage(
     mmsi = 237772000,
     status = 8,
@@ -18,33 +22,76 @@ aismsg = aislib.AISPositionReportMessage(
 )
 ais = aislib.AIS(aismsg)
 payload = ais.build_payload(False)
-print(payload)
-print("nav status: %d" % aismsg.get_attr("status"))
-
+print(payload) # !AIVDM,1,1,,A,13RhLp801;QjL>0DD38:t?w@2D7k,0*3E
 aismsg2 = ais.decode(payload)
 ais2 = aislib.AIS(aismsg2)
 payload2 = ais2.build_payload(False)
 assert payload ==  payload2
-print("nav status: %d" % aismsg2.get_attr("status"))
 
-#print aismsg.id
-#print aismsg.repeat
+#
+# Tests for Message Type 2 (payload format as type 1)
+#
 
-#bitstr = aismsg.build_bitstream() 
-#print bitstr.bin
-#print bitstr.len
+print('Tests for Message Type 2 (payload format as type 1)')
+
+aismsg = aislib.AISPositionReportMessage(
+    id = 2,
+    mmsi = 237772000,
+    status = 8,
+    sog = 75,
+    pa = 1,
+    lon = (25*60+00)*10000,
+    lat = (35*60+30)*10000,
+    cog = 2800,
+    ts = 40,
+    raim = 1,
+    comm_state = 82419   
+)
+ais = aislib.AIS(aismsg)
+payload = ais.build_payload(False)
+print(payload) # !AIVDM,1,1,,A,23RhLp801;QjL>0DD38:t?w@2D7k,0*3D
+aismsg2 = ais.decode(payload)
+ais2 = aislib.AIS(aismsg2)
+payload2 = ais2.build_payload(False)
+assert payload ==  payload2
+
+#
+# Tests for Message Type 3 (payload format as type 1)
+#
+
+print('Tests for Message Type 3 (payload format as type 1)')
+
+aismsg = aislib.AISPositionReportMessage(
+    id = 3,
+    mmsi = 237772000,
+    status = 8,
+    sog = 75,
+    pa = 1,
+    lon = (25*60+00)*10000,
+    lat = (35*60+30)*10000,
+    cog = 2800,
+    ts = 40,
+    raim = 1,
+    comm_state = 82419   
+)
+ais = aislib.AIS(aismsg)
+payload = ais.build_payload(False)
+print(payload) # !AIVDM,1,1,,A,33RhLp801;QjL>0DD38:t?w@2D7k,0*3C
+aismsg2 = ais.decode(payload)
+ais2 = aislib.AIS(aismsg2)
+payload2 = ais2.build_payload(False)
+assert payload ==  payload2
 
 # 
 # Tests for Message Type 24 Format A
 #
-del aismsg
-del aismsg2
-#print aislib.AISString2Bits('ABC')
-aismsg = aislib.AISStaticDataReportAMessage(mmsi=237772000,shipname=aislib.AISString2Bits('OF THE HIGH SEAS').int)
+
+print('Tests for Message Type 24 Format A')
+
 aismsg = aislib.AISStaticDataReportAMessage(mmsi=237772000,shipname='OF THE HIGH SEAS')
 ais = aislib.AIS(aismsg)
 payload = ais.build_payload(False)
-print(payload)
+print(payload) # !AIVDM,1,1,,A,H3RhLp0tJ1@PF0PTLR1<D5<00000,0*68
 aismsg2 = ais.decode(payload)
 ais2 = aislib.AIS(aismsg2)
 payload2 = ais2.build_payload(False)
@@ -53,13 +100,16 @@ assert payload ==  payload2
 # 
 # Tests for Message Type 24 Format B
 #
+
+print('Tests for Message Type 24 Format B')
+
 aismsg = aislib.AISStaticDataReportBMessage(mmsi=237772000,shiptype=36,
          vendorid='DIY',
          callsign='SVXYZ',
          to_bow=5,to_stern=5,to_port=1,to_starboard=1)
 ais = aislib.AIS(aismsg)
 payload = ais.build_payload(False)
-print(payload)
+print(payload) # !AIVDM,1,1,,A,H3RhLp4T49I0000CFHIJ000`5110,0*64
 aismsg2 = ais.decode(payload)
 ais2 = aislib.AIS(aismsg2)
 payload2 = ais2.build_payload(False)
@@ -68,7 +118,9 @@ assert payload ==  payload2
 # 
 # Tests for Message Type 5
 #
-print(' Tests for Message Type 5')
+
+print('Tests for Message Type 5')
+
 aismsg = aislib.AISStaticAndVoyageReportMessage(mmsi=237772000,
          imo=0, 
          callsign='SVXYZ',
@@ -79,7 +131,7 @@ aismsg = aislib.AISStaticAndVoyageReportMessage(mmsi=237772000,
          destination='STROFADES')
 ais = aislib.AIS(aismsg)
 payload = ais.build_payload(False)
-print(payload)
+print(payload) # !AIVDM,1,1,,A,53RhLp000001=IQU`00tJ1@PF0PTLR1<D5<0000T0`5115GD?2Tm4SiPA1Dh00000000000,2*07
 aismsg2 = ais.decode(payload)
 ais2 = aislib.AIS(aismsg2)
 payload2 = ais2.build_payload(False)
@@ -89,7 +141,7 @@ assert payload ==  payload2
 # Tests for Message Type 21
 #
 
-print(' Tests for Message Type 21')
+print('Tests for Message Type 21')
 
 aismsg = aislib.AISAtonReport(
          mmsi = 992659995, 

--- a/aistest.py
+++ b/aistest.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import aislib
 #
 # Tests for Message Type 1
@@ -16,14 +18,14 @@ aismsg = aislib.AISPositionReportMessage(
 )
 ais = aislib.AIS(aismsg)
 payload = ais.build_payload(False)
-print payload
-print "nav status: %d" % aismsg.get_attr("status")
+print(payload)
+print("nav status: %d" % aismsg.get_attr("status"))
 
 aismsg2 = ais.decode(payload)
 ais2 = aislib.AIS(aismsg2)
 payload2 = ais2.build_payload(False)
 assert payload ==  payload2
-print "nav status: %d" % aismsg2.get_attr("status")
+print("nav status: %d" % aismsg2.get_attr("status"))
 
 #print aismsg.id
 #print aismsg.repeat
@@ -42,7 +44,7 @@ aismsg = aislib.AISStaticDataReportAMessage(mmsi=237772000,shipname=aislib.AISSt
 aismsg = aislib.AISStaticDataReportAMessage(mmsi=237772000,shipname='OF THE HIGH SEAS')
 ais = aislib.AIS(aismsg)
 payload = ais.build_payload(False)
-print payload
+print(payload)
 aismsg2 = ais.decode(payload)
 ais2 = aislib.AIS(aismsg2)
 payload2 = ais2.build_payload(False)
@@ -57,7 +59,7 @@ aismsg = aislib.AISStaticDataReportBMessage(mmsi=237772000,shiptype=36,
          to_bow=5,to_stern=5,to_port=1,to_starboard=1)
 ais = aislib.AIS(aismsg)
 payload = ais.build_payload(False)
-print payload
+print(payload)
 aismsg2 = ais.decode(payload)
 ais2 = aislib.AIS(aismsg2)
 payload2 = ais2.build_payload(False)
@@ -66,7 +68,7 @@ assert payload ==  payload2
 # 
 # Tests for Message Type 5
 #
-print ' Tests for Message Type 5'
+print(' Tests for Message Type 5')
 aismsg = aislib.AISStaticAndVoyageReportMessage(mmsi=237772000,
          imo=0, 
          callsign='SVXYZ',
@@ -77,7 +79,7 @@ aismsg = aislib.AISStaticAndVoyageReportMessage(mmsi=237772000,
          destination='STROFADES')
 ais = aislib.AIS(aismsg)
 payload = ais.build_payload(False)
-print payload
+print(payload)
 aismsg2 = ais.decode(payload)
 ais2 = aislib.AIS(aismsg2)
 payload2 = ais2.build_payload(False)

--- a/aistest.py
+++ b/aistest.py
@@ -84,3 +84,39 @@ aismsg2 = ais.decode(payload)
 ais2 = aislib.AIS(aismsg2)
 payload2 = ais2.build_payload(False)
 assert payload ==  payload2
+
+# 
+# Tests for Message Type 21
+#
+
+print(' Tests for Message Type 21')
+
+aismsg = aislib.AISAtonReport(
+         mmsi = 992659995, 
+         aid_type = 28, 
+         name = 'MEASUREMENT BUOY', 
+         lon = 10769643, 
+         lat = 37578551, 
+         virtual_aid = 0)
+ais = aislib.AIS(aismsg)
+payload = ais.build_payload(False)
+print(payload)  # !AIVDM,1,1,,A,E>jc:6v6RPaba2VRW:@1:WdP0000a5CcArkVp00000N000,0*4F
+aismsg2 = ais.decode(payload)
+ais2 = aislib.AIS(aismsg2)
+payload2 = ais2.build_payload(False)
+assert payload == payload2
+
+aismsg = aislib.AISAtonReport(
+         mmsi = 992659999, 
+         aid_type = 30, 
+         name = 'TEST AREA DEMARC. 1', 
+         lon = 10769878, 
+         lat = 37578659, 
+         virtual_aid = 1)
+ais = aislib.AIS(aismsg)
+payload = ais.build_payload(False)
+print(payload)  # !AIVDM,1,1,,A,E>jc:7w:2ab@0a2Ph22VPa1o@HP0a5GFArklH00000N010,0*09
+aismsg2 = ais.decode(payload)
+ais2 = aislib.AIS(aismsg2)
+payload2 = ais2.build_payload(False)
+assert payload == payload2


### PR DESCRIPTION
I have put aislib to good use in my own projects over the past few years, made the code Python 3 compatible using futurize, added capabilities for handling more message types and modified minor things.